### PR TITLE
Change code to be IE11-compatible

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = function formatMobiledoc(doc) {
     var key = list.key;
     if (doc[key]) {
       pairs.push({
-        key,
+        key: key,
         value: utils.multiLineArray(doc[key].map(list.formatter))
       });
     }

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -15,7 +15,7 @@ function atom(atom) {
   if (atomPayload) {
     atom[2] = utils.prettyJSON(atomPayload);
   }
-  return utils.arround(atom.join(', '));
+  return utils.around(atom.join(', '));
 }
 
 function card(card) {
@@ -26,7 +26,7 @@ function card(card) {
   if (payload) {
     card[1] = utils.prettyJSON(payload);
   }
-  return utils.arround(card.join(', '));
+  return utils.around(card.join(', '));
 }
 
 function section(section) {
@@ -43,13 +43,13 @@ function section(section) {
   if (markers) {
     section[2] = utils.multiLineArray(markers.map(utils.oneline));
   }
-  return utils.arround(section.join(', '));
+  return utils.around(section.join(', '));
 }
 
 module.exports = {
-  version,
+  version: version,
   markup: utils.oneline,
-  atom,
-  card,
-  section
+  atom: atom,
+  card: card,
+  section: section
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,10 +1,15 @@
 function indent(multiline, depth) {
-  var indent = Array(depth).fill(' ').join('');
+  var indent = [];
+  while (depth > 0) {
+    indent.push(' ');
+    depth--;
+  }
+  indent = indent.join('');
   return multiline.replace(/^/gm, indent);
 }
 
-function arround(inner) {
-  return `[${inner}]`;
+function around(inner) {
+  return '[' + inner + ']';
 }
 
 function prettyJSON(obj) {
@@ -13,7 +18,7 @@ function prettyJSON(obj) {
 
 function oneline(obj) {
   if (Array.isArray(obj)) {
-    return arround(obj.map(oneline).join(', '));
+    return around(obj.map(oneline).join(', '));
   } else {
     return JSON.stringify(obj);
   }
@@ -31,9 +36,9 @@ function multiLineArray(items) {
 
 
 module.exports = {
-  indent,
-  arround,
-  prettyJSON,
-  oneline,
-  multiLineArray
+  indent: indent,
+  around: around,
+  prettyJSON: prettyJSON,
+  oneline: oneline,
+  multiLineArray: multiLineArray
 };


### PR DESCRIPTION
Removes usage of template strings and `Array.fill`. Expand shorthand
Object literal properties to include key and value: (`key` -> `key: value`).

Also fix typo "arround" -> "around".

ember-browserify doesn't appear to transpile its code, so the mobiledoc-kit demo
fails to load when run in IE11 when the [demo includes mobiledoc-pretty-json-renderer](https://github.com/bustlelabs/mobiledoc-kit/pull/420).
